### PR TITLE
Fix classify_brace variable mismatch

### DIFF
--- a/script/compgenz
+++ b/script/compgenz
@@ -30,10 +30,10 @@ BEGIN {
 # LOpt: long option
 # returns: string formated alike "(-s --longopt)" or "(1 : -)"
 function classify_brace(    SOpt,    LOpt){
-    if (LOpt ~ /--?help/ || sOpt ~ /-help/ || LOpt ~ /--?version/) {
+    if (LOpt ~ /--?help/ || SOpt ~ /-help/ || LOpt ~ /--?version/) {
         return "(: - 1)"
     } else if (SOpt !="" && LOpt !="") {
-    return sprintf("(%s %s)",ShortOption[0],LongOption[0])
+        return sprintf("(%s %s)", SOpt, LOpt)
     } else {  return "" }
 }
 


### PR DESCRIPTION
## Summary
- use correct variable in `classify_brace`
- utilize passed parameters when forming option brace

## Testing
- `make compile` *(fails: /bin/zsh not found)*
- `echo "Usage: foo [options]\n  -h --help  Show help" | gawk -f script/compgenz test`

------
https://chatgpt.com/codex/tasks/task_e_68407830a5f4832e9eaa483a04a2607c