### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ some completion files might originate from sources I lost track of, contact me i
 ## to install
 ```echo "fpath=($PWD/ \$fpath)">> ~/.zshrc```
 
-## dynamicly generate a completion file for an executable
+## dynamically generate a completion file for an executable
 ```executable --help | script/compgenz executable > _executable```


### PR DESCRIPTION
## Summary
- fix misspelling in README

## Testing
- `grep -n dynamically README.md`


------
https://chatgpt.com/codex/tasks/task_e_6840878e85b0832e8fc1e66c6c8597ab