### PR TITLE
Fix eralchemy license header

### DIFF
--- a/_eralchemy
+++ b/_eralchemy
@@ -1,11 +1,11 @@
 #compdef eralchemy
 
-# erlachemy-zsh-completion (C) by Henrik Lindgren henrikprojekt at gmail.com
+# eralchemy-zsh-completion (C) by Henrik Lindgren henrikprojekt at gmail.com
 #
 # It is free software; you can redistribute it and/or modify it under the terms of either:
 #
 # a) the GNU General Public License as published by the Free Software Foundation;
-#    either external linkversion 1, or (at your option) any later versionexternal link, or
+#    either version 1, or (at your option) any later version, or
 #
 # b) the "Artistic License".
 


### PR DESCRIPTION
## Summary
- fix spelling of "eralchemy" in completion script comment
- clean up license header removing garbled text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840876f5698832e8ac1eaabaa155efd